### PR TITLE
Update ViewController.swift swapping values in Serial Number Toggle

### DIFF
--- a/About This Hack/ViewController.swift
+++ b/About This Hack/ViewController.swift
@@ -143,14 +143,23 @@ class ViewController: NSViewController {
         blVersion.needsDisplay = true
     }
     
-    @IBAction func hideSerialNumber(_ sender: NSButton) {
-        print("Serial Number toggled")
-        if serialNumber.stringValue == "" {
-            serialNumber.stringValue = HardwareCollector.SerialNumberString
-        } else {
-            serialNumber.stringValue = ""
-        }
-    }
+//    @IBAction func hideSerialNumber(_ sender: NSButton) {
+//        print("Serial Number toggled")
+//        if serialNumber.stringValue == "" {
+//            serialNumber.stringValue = HardwareCollector.SerialNumberString
+//        } else {
+//            serialNumber.stringValue = ""
+//        }
+//    }
+
+     @IBAction func hideSerialNumber(_ sender: NSButton) {
+          print("Serial Number toggled")
+          if serialNumber.stringValue == HardwareCollector.SerialNumberString {
+              serialNumber.stringValue = ""
+          } else {
+              erialNumber.stringValue = HardwareCollector.SerialNumberString
+          }
+      }
     
     @IBAction func showSystemReport(_ sender: NSButton) {
         print("System Report...")


### PR DESCRIPTION
Swapping values in Serial Number Toggle so that clicking the Serial Number element toggles between `HardwareCollector.SerialNumberString` and `""`.

By default, the value only changes the first time it is clicked, remaining empty indefinitely while the app is running.
Small cosmetic improvement, in my opinion, dependent of course on you liking it too.

Regards, Emilio.