### PR TITLE
Metal info is next to VRAM, space has been added

### DIFF
--- a/About This Hack/HardwareCollectors/HCGPU.swift
+++ b/About This Hack/HardwareCollectors/HCGPU.swift
@@ -31,7 +31,7 @@ class HCGPU {
         vram = vram.trimmingCharacters(in: .whitespaces)
         metal = metal.trimmingCharacters(in: .whitespaces)
         
-        return "\(chipset) \(vram)(Metal \(metal))".trimmingCharacters(in: .whitespaces)
+        return "\(chipset) \(vram) (Metal \(metal))".trimmingCharacters(in: .whitespaces)
     }()
     
     static func getGPU() -> String {


### PR DESCRIPTION
Metal is next to VRAM, with no separation between the two.

<img width="280" alt="No space" src="https://github.com/user-attachments/assets/8faff016-0c83-4641-8570-0bd654b98b27">

```swift
return "\(chipset) \(vram)(Metal \(metal))".trimmingCharacters(in: .whitespaces)
```
A space has been added to separate them.

<img width="288" alt="Space" src="https://github.com/user-attachments/assets/8740a9dc-6b40-4ac8-82e6-4a07f0d7d69e">

```swift
return "\(chipset) \(vram) (Metal \(metal))".trimmingCharacters(in: .whitespaces)
```
It's a very small change but I like showing the GPU info better this way.