### PR TITLE
Fix excessive spacing between segmented control and content in macOS Tahoe

### DIFF
--- a/About This Hack/ViewController.swift
+++ b/About This Hack/ViewController.swift
@@ -100,12 +100,10 @@ class ViewController: NSViewController {
         blPrefix.isHidden = false
         blVersion.isHidden = false
         
-        // Hide credits text in Overview tab when running on Tahoe
-        // This prevents the text from being hidden below the window edge due to
-        // different vertical positioning of elements in Tahoe
-        let isTahoe = HCVersion.shared.osVersion == .tahoe
-        creditText.isHidden = isTahoe
-        creditText.alphaValue = isTahoe ? 0 : 1
+        // Show credits text - no longer needs to be hidden in Tahoe since
+        // we've adjusted the window size to accommodate the increased toolbar height
+        creditText.isHidden = false
+        creditText.alphaValue = 1
         
         CATransaction.commit()
     }


### PR DESCRIPTION
macOS Tahoe increased the default toolbar height, causing content in the fixed-size window to appear with excessive spacing below the segmented control. In Tahoe, the toolbar takes up more vertical space. We need to compensate by making the window slightly taller.

**WindowController.swift**

- Added OS version detection via `ProcessInfo.processInfo.operatingSystemVersion` to detect if running on Tahoe without waiting for HCVersion
- Window height now dynamically adjusts to 370px on Tahoe (vs 350px on prior versions).

**ViewController.swift**

- Removed Tahoe-specific workaround that hid credits text, this text is hidden until UI is completed, then displays on all macOS versions with adjusted window size.

```swift
private var windowSize: NSSize {
    let isTahoe = ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 26
    return isTahoe ? NSSize(width: 580, height: 370) : NSSize(width: 580, height: 350)
}
```

The 20px height increase compensates for the toolbar height change without modifying UI layouts or storyboard constraints.

<img width="692" height="462" alt="Tahoe-credits" src="https://github.com/user-attachments/assets/c770cb16-4ab5-4ef3-a170-b250e289459d" />
